### PR TITLE
Do not send unneeded updates for devices that are not available

### DIFF
--- a/plugin.py
+++ b/plugin.py
@@ -279,16 +279,16 @@ class BasePlugin:
                 if dev.state() == False:
                     UpdateDevice(unit, 0, 'Off', not dev.available())
                 elif dev.state() == True:
-                    UpdateDevice(unit, 1, 'On', not dev.available())
+                    if dev.available():
+                        UpdateDevice(unit, 1, 'On', not dev.available())
+                    else:
+                        UpdateDevice(unit, 0, 'Off', not dev.available())
+                        Domoticz.Log('DeviceID='+Devices[unit].DeviceID+' Turned off because device is offline.')
                 else:
                     Domoticz.Log('DeviceID='+Devices[unit].DeviceID+' State update skiped. status = '+str(dev.state()))
 
                 #if dev.device_type() == 'cover' and dev.state() != 'Stop':
                 #    UpdateDevice(unit, 1, 'Stop', not dev.available())
-
-                if dev.state() == True and not dev.available():
-                    UpdateDevice(unit, 0, 'Off', not dev.available())
-                    Domoticz.Log('DeviceID='+Devices[unit].DeviceID+' Turned off because device is offline.')
 
         except Exception as err:
             Domoticz.Error("handleThread: "+str(err)+' line '+format(sys.exc_info()[-1].tb_lineno))


### PR DESCRIPTION
A device that is not available, is being turned on very briefly.
This is causing that 'LightingLog' table in the Domoticz database becomes very large. It also could be generating a lot of events if the device is being used in script-triggers.

The Domoticz log shows, that the device is only turned on for 70 ms.
```
2023-06-16 21:24:48.230 TUYA: DEV name=RGB Christmas Light state=True id=999987013c6105883db6 online=False
2023-06-16 21:24:48.288 TUYA: Update 1:'On' (Kerstboom verlichting) TimedOut=True
2023-06-16 21:24:48.353 TUYA: Update 0:'Off' (Kerstboom verlichting) TimedOut=True
2023-06-16 21:24:48.354 TUYA: DeviceID=999987013c6105883db6 Turned off because device is offline.
```
This however happens every 70 seconds.

The code change prevents the temporarily turning 'On' and 'Off' of the device, and only activates the final state.
